### PR TITLE
fix: increase key length in test

### DIFF
--- a/client/internal/testutil/certs.go
+++ b/client/internal/testutil/certs.go
@@ -45,7 +45,7 @@ func GenerateCertAndKeyAsEncodedPFXData(template CertTemplate) (string, error) {
 	x509Template.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
 	x509Template.BasicConstraintsValid = true
 
-	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This increases the length of the private key generated by the `GenerateCertAndKeyAsEncodedPFXData()` function in `certs.go`. 