### PR TITLE
feat(client): add custom usage message

### DIFF
--- a/client/cmd/client/main.go
+++ b/client/cmd/client/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/bootstrap"
+	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/build"
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/kubeconfig"
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/log"
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/telemetry"
@@ -44,6 +45,12 @@ func init() {
 	flag.BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip TLS verification when connecting to the control plane")
 	flag.BoolVar(&config.EnsureAuthorizedClient, "ensure-authorized", false, "ensure the specified kubeconfig contains an authorized clientset before bootstrapping")
 	flag.DurationVar(&config.Deadline, "deadline", 0, "the deadline within which bootstrapping must succeed")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s - %s:\n", os.Args[0], build.GetVersion())
+		flag.PrintDefaults()
+	}
+
 	flag.Parse()
 }
 


### PR DESCRIPTION
```
Usage of ./aks-secure-tls-bootstrap-client-arm64 - v0.0.1:
  -aad-resource string
        resource (audience) used to request JWT tokens from AAD for authentication
  -apiserver-fqdn string
        FQDN of the apiserver
  -cert-dir string
        the directory where kubelet's new client certificate/key pair will be stored - this should be the same as the --cert-dir passed to the kubelet
  -cloud-provider-config string
        path to the cloud provider config file
  -cluster-ca-file string
        path to the cluster CA file
  -config-file string
        path to the configuration file, settings in this file will take priority over command line arguments
  -deadline duration
        the deadline within which bootstrapping must succeed
  -ensure-authorized
        ensure the specified kubeconfig contains an authorized clientset before bootstrapping
  -insecure-skip-tls-verify
        skip TLS verification when connecting to the control plane
  -kubeconfig string
        path to the kubeconfig - if this file does not exist, the generated kubeconfig will be placed there - this should be the same as the --kubeconfig passed to the kubelet
  -log-file string
        path to a file where logs will be written, will be created if it does not already exist
  -next-proto string
        ALPN next proto value
  -user-assigned-identity-id string
        client ID of the user-assigned identity to use when requesting MSI tokens from IMDS - if not specified, the kubelet identity from the cloud provider config will be used
  -verbose
        enable verbose log output
```