### PR TITLE
fix: retry get access token from imds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ go.work
 .idea
 .vscode
 .vs
+
+.mise

--- a/client/internal/bootstrap/auth.go
+++ b/client/internal/bootstrap/auth.go
@@ -6,7 +6,9 @@ package bootstrap
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/cloud"
@@ -47,10 +49,7 @@ func extractAccessToken(ctx context.Context, token *adal.ServicePrincipalToken, 
 func (c *client) getToken(ctx context.Context, config *Config) (string, error) {
 	logger := log.MustGetLogger(ctx)
 
-	userAssignedID := config.CloudProviderConfig.UserAssignedIdentityID
-	if config.UserAssignedIdentityID != "" {
-		userAssignedID = config.UserAssignedIdentityID
-	}
+	userAssignedID := getUserAssignedIdentityID(config)
 
 	if userAssignedID != "" {
 		logger.Info("generating MSI access token", zap.String("clientId", userAssignedID))
@@ -74,6 +73,60 @@ func (c *client) getToken(ctx context.Context, config *Config) (string, error) {
 	}
 
 	return c.extractAccessTokenFunc(ctx, servicePrincipalToken, false)
+}
+
+func getUserAssignedIdentityID(config *Config) string {
+	if config == nil {
+		return ""
+	}
+	if config.UserAssignedIdentityID != "" {
+		return config.UserAssignedIdentityID
+	}
+	if config.CloudProviderConfig == nil {
+		return ""
+	}
+	return config.CloudProviderConfig.UserAssignedIdentityID
+}
+
+func isManagedIdentityTokenRequest(config *Config) bool {
+	if getUserAssignedIdentityID(config) != "" {
+		return true
+	}
+	return config != nil && config.CloudProviderConfig != nil && config.CloudProviderConfig.ClientID == clientIDForMSI
+}
+
+func isTerminalGetTokenError(err error, config *Config) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var tokenRefreshErr adal.TokenRefreshError
+	if !errors.As(err, &tokenRefreshErr) {
+		return true
+	}
+
+	resp := tokenRefreshErr.Response()
+	if resp == nil {
+		return false
+	}
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests, http.StatusRequestTimeout:
+		return false
+	case http.StatusNotFound, http.StatusGone:
+		return !isManagedIdentityTokenRequest(config)
+	case http.StatusBadRequest:
+		return !isRetryableManagedIdentityNotFoundError(err, config)
+	default:
+		return resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError
+	}
+}
+
+func isRetryableManagedIdentityNotFoundError(err error, config *Config) bool {
+	return isManagedIdentityTokenRequest(config) && strings.Contains(strings.ToLower(err.Error()), "identity not found")
 }
 
 func getServicePrincipalToken(ctx context.Context, resource string, cloudProviderConfig *cloud.ProviderConfig) (*adal.ServicePrincipalToken, error) {

--- a/client/internal/bootstrap/auth_test.go
+++ b/client/internal/bootstrap/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -246,4 +247,151 @@ func TestGetToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsTerminalGetTokenError(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *Config
+		err      error
+		expected bool
+	}{
+		{
+			name:     "context deadline exceeded is terminal",
+			config:   &Config{},
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "non token refresh error is terminal",
+			config:   &Config{},
+			err:      errors.New("invalid cloud config"),
+			expected: true,
+		},
+		{
+			name: "service principal bad request is terminal",
+			config: &Config{
+				CloudProviderConfig: &cloud.ProviderConfig{
+					ClientID: "service-principal-id",
+				},
+			},
+			err: &fakeTokenRefreshError{
+				resp: &http.Response{StatusCode: http.StatusBadRequest},
+				err:  errors.New(`adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_client"}`),
+			},
+			expected: true,
+		},
+		{
+			name: "managed identity identity not found is retryable",
+			config: &Config{
+				CloudProviderConfig: &cloud.ProviderConfig{
+					ClientID:               clientIDForMSI,
+					UserAssignedIdentityID: "identity-id",
+				},
+			},
+			err: &fakeTokenRefreshError{
+				resp: &http.Response{StatusCode: http.StatusBadRequest},
+				err:  errors.New(`adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"Identity not found"}`),
+			},
+			expected: false,
+		},
+		{
+			name: "managed identity not found response is retryable",
+			config: &Config{
+				UserAssignedIdentityID: "identity-id",
+			},
+			err: &fakeTokenRefreshError{
+				resp: &http.Response{StatusCode: http.StatusNotFound},
+				err:  errors.New("adal: retryable IMDS status"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, isTerminalGetTokenError(c.err, c.config))
+		})
+	}
+}
+
+func TestGetAccessToken(t *testing.T) {
+	t.Run("retries managed identity identity not found errors", func(t *testing.T) {
+		attempts := 0
+		sleeps := 0
+		client := &client{
+			getTokenFunc: func(ctx context.Context, config *Config) (string, error) {
+				attempts++
+				if attempts < 3 {
+					return "", &fakeTokenRefreshError{
+						resp: &http.Response{StatusCode: http.StatusBadRequest},
+						err:  errors.New(`adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"Identity not found"}`),
+					}
+				}
+				return "token", nil
+			},
+			sleepFunc: func(ctx context.Context, duration time.Duration) error {
+				sleeps++
+				assert.Equal(t, getAccessTokenRetryInterval, duration)
+				return nil
+			},
+		}
+
+		token, err := client.getAccessToken(telemetry.WithTracing(log.NewTestContext()), &Config{
+			GetAccessTokenTimeout: time.Minute,
+			CloudProviderConfig: &cloud.ProviderConfig{
+				ClientID:               clientIDForMSI,
+				UserAssignedIdentityID: "identity-id",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "token", token)
+		assert.Equal(t, 3, attempts)
+		assert.Equal(t, 2, sleeps)
+	})
+
+	t.Run("does not retry terminal errors", func(t *testing.T) {
+		attempts := 0
+		client := &client{
+			getTokenFunc: func(ctx context.Context, config *Config) (string, error) {
+				attempts++
+				return "", errors.New("invalid cloud config")
+			},
+			sleepFunc: func(ctx context.Context, duration time.Duration) error {
+				t.Fatalf("sleep should not be called for terminal errors")
+				return nil
+			},
+		}
+
+		token, err := client.getAccessToken(telemetry.WithTracing(log.NewTestContext()), &Config{
+			GetAccessTokenTimeout: time.Minute,
+		})
+		assert.Empty(t, token)
+		assert.EqualError(t, err, "invalid cloud config")
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("stops retrying when context deadline is exceeded", func(t *testing.T) {
+		attempts := 0
+		client := &client{
+			getTokenFunc: func(ctx context.Context, config *Config) (string, error) {
+				attempts++
+				return "", &fakeTokenRefreshError{
+					resp: &http.Response{StatusCode: http.StatusInternalServerError},
+					err:  errors.New("temporary token service failure"),
+				}
+			},
+			sleepFunc: func(ctx context.Context, duration time.Duration) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		token, err := client.getAccessToken(telemetry.WithTracing(log.NewTestContext()), &Config{
+			GetAccessTokenTimeout: 10 * time.Millisecond,
+		})
+		assert.Empty(t, token)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, 1, attempts)
+	})
 }

--- a/client/internal/bootstrap/client.go
+++ b/client/internal/bootstrap/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/imds"
 	"github.com/Azure/aks-secure-tls-bootstrap/client/internal/kubeconfig"
@@ -22,7 +23,14 @@ type client struct {
 	imdsClient             imds.Client
 	getServiceClientFunc   getServiceClientFunc
 	extractAccessTokenFunc extractAccessTokenFunc
+	getTokenFunc           func(ctx context.Context, config *Config) (string, error)
+	sleepFunc              func(ctx context.Context, duration time.Duration) error
 }
+
+const (
+	getAccessTokenRetryInterval    = time.Second
+	getAccessTokenRetryMaxAttempts = 30
+)
 
 func newClient(ctx context.Context) *client {
 	return &client{
@@ -30,6 +38,7 @@ func newClient(ctx context.Context) *client {
 		imdsClient:             imds.NewClient(ctx),
 		getServiceClientFunc:   getServiceClient,
 		extractAccessTokenFunc: extractAccessToken,
+		sleepFunc:              sleepWithContext,
 	}
 }
 
@@ -157,11 +166,38 @@ func (c *client) getAccessToken(ctx context.Context, config *Config) (string, er
 	endSpan := telemetry.StartSpan(ctx, "GetAccessToken")
 	defer endSpan()
 
-	token, err := c.getToken(getAccessTokenCtx, config)
-	if err != nil {
-		return "", err
+	logger := log.MustGetLogger(getAccessTokenCtx)
+
+	getTokenFunc := c.getTokenFunc
+	if getTokenFunc == nil {
+		getTokenFunc = c.getToken
 	}
-	return token, nil
+	sleepFunc := c.sleepFunc
+	if sleepFunc == nil {
+		sleepFunc = sleepWithContext
+	}
+
+	for attempt := 1; attempt <= getAccessTokenRetryMaxAttempts; attempt++ {
+		token, err := getTokenFunc(getAccessTokenCtx, config)
+		if err == nil {
+			return token, nil
+		}
+		if isTerminalGetTokenError(err, config) || attempt == getAccessTokenRetryMaxAttempts {
+			return "", err
+		}
+
+		logger.Warn("failed to generate access token, retrying",
+			zap.Int("attempt", attempt),
+			zap.Int("maxAttempts", getAccessTokenRetryMaxAttempts),
+			zap.Duration("retryInterval", getAccessTokenRetryInterval),
+			zap.Error(err),
+		)
+		if err := sleepFunc(getAccessTokenCtx, getAccessTokenRetryInterval); err != nil {
+			return "", err
+		}
+	}
+
+	return "", fmt.Errorf("failed to generate access token after exhausting retries")
 }
 
 func (c *client) getServiceClient(ctx context.Context, token string, cfg *Config) (v1.SecureTLSBootstrapServiceClient, closeFunc, error) {
@@ -248,6 +284,27 @@ func (c *client) getCredential(ctx context.Context, serviceClient v1.SecureTLSBo
 		return nil, fmt.Errorf("failed to decode cert data from bootstrap server: %w", err)
 	}
 	return certPEM, nil
+}
+
+func sleepWithContext(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (c *client) generateKubeconfig(ctx context.Context, certPEM, keyPEM []byte, config *kubeconfig.Config) (*api.Config, error) {


### PR DESCRIPTION
##Summary

Add client-side retries for MSI access token acquisition during bootstrap.

Today, the client makes a single outer getAccessToken() attempt, so transient managed identity propagation/availability issues can fail the whole bootstrap even when a retry
a few seconds later would succeed. This is especially visible for errors like IMDS/ADAL returning "Identity not found" shortly after node startup.

##What changed

 - Added an outer retry loop in client/internal/bootstrap/client.go:getAccessToken()
 - Retry policy is now:
  - 30 attempts
  - 1 second between attempts
  - still bounded by the existing GetAccessTokenTimeout
 - Added terminal error handling so we do not retry obviously non-retryable getToken() failures
 - Kept managed identity "Identity not found" failures retryable, since they can be transient during identity attachment/propagation
 - Added/updated unit tests in client/internal/bootstrap/auth_test.go to cover:
  - retrying transient MSI failures
  - not retrying terminal failures
  - stopping when the access token timeout is reached

##Why

Bootstrap already has retry behavior in other networked parts of the flow, but MSI token acquisition was effectively missing the same protection at the client layer. This
change makes bootstrap more resilient to short-lived identity readiness issues without broadening retries across the entire bootstrap flow.
