### PR TITLE
fix(client): add grpc.ConnectParams with Backoff override to avoid conflicting retry/backoff strategies

### DIFF
--- a/client/internal/bootstrap/grpc.go
+++ b/client/internal/bootstrap/grpc.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
@@ -54,6 +55,15 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
 				AccessToken: token,
 			}),
+		}),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  1 * time.Second,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   5 * time.Second,
+			},
+			MinConnectTimeout: 10 * time.Second,
 		}),
 		grpc.WithUnaryInterceptor(retry.UnaryClientInterceptor(
 			retry.WithOnRetryCallback(getGRPCOnRetryCallbackFunc()),

--- a/client/internal/bootstrap/grpc.go
+++ b/client/internal/bootstrap/grpc.go
@@ -67,7 +67,7 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 		// transport/connection-level config
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff:           grpcConnectionBackoffConfig,
-			MinConnectTimeout: 10 * time.Second,
+			MinConnectTimeout: 7 * time.Second,
 		}),
 		// RPC-level retry config
 		grpc.WithUnaryInterceptor(retry.UnaryClientInterceptor(

--- a/client/internal/bootstrap/grpc.go
+++ b/client/internal/bootstrap/grpc.go
@@ -66,8 +66,11 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 		}),
 		// transport/connection-level config
 		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff:           grpcConnectionBackoffConfig,
-			MinConnectTimeout: 7 * time.Second,
+			Backoff: grpcConnectionBackoffConfig,
+			// MinConnectTimeout caps the per-attempt connection timeout (default: 20s).
+			// 5s balances fast retry cycles (~8s/cycle) against headroom for first-connection
+			// latency through new LB paths — healthy intra-Azure TCP+TLS 1.3 handshakes complete in <1s.
+			MinConnectTimeout: 5 * time.Second,
 		}),
 		// RPC-level retry config
 		grpc.WithUnaryInterceptor(retry.UnaryClientInterceptor(

--- a/client/internal/bootstrap/grpc.go
+++ b/client/internal/bootstrap/grpc.go
@@ -47,6 +47,14 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 		return nil, nil, fmt.Errorf("failed to get TLS config: %w", err)
 	}
 
+	// override max delay to 3s (default is 120s) - this ensures the gRPC subchannel
+	// re-attempts a real TCP+TLS connection at least every 3s, which aligns with
+	// the ~2s RPC-level retry cadence. Without this cap, the subchannel exponential
+	// backoff grows to 120s, causing the retry interceptor to receive cached errors
+	// from the last real attempt rather than triggering new connection attempts.
+	grpcConnectionBackoffConfig := backoff.DefaultConfig
+	grpcConnectionBackoffConfig.MaxDelay = 3 * time.Second
+
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("%s:443", cfg.APIServerFQDN),
 		grpc.WithUserAgent(internalhttp.GetUserAgent()),
@@ -56,15 +64,12 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 				AccessToken: token,
 			}),
 		}),
+		// transport/connection-level retry config
 		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay:  1 * time.Second,
-				Multiplier: 1.6,
-				Jitter:     0.2,
-				MaxDelay:   5 * time.Second,
-			},
+			Backoff:           grpcConnectionBackoffConfig,
 			MinConnectTimeout: 10 * time.Second,
 		}),
+		// RPC-level retry config
 		grpc.WithUnaryInterceptor(retry.UnaryClientInterceptor(
 			retry.WithOnRetryCallback(getGRPCOnRetryCallbackFunc()),
 			retry.WithBackoff(retry.BackoffLinearWithJitter(2*time.Second, 0.25)),

--- a/client/internal/bootstrap/grpc.go
+++ b/client/internal/bootstrap/grpc.go
@@ -64,7 +64,7 @@ func getServiceClient(token string, cfg *Config) (v1.SecureTLSBootstrapServiceCl
 				AccessToken: token,
 			}),
 		}),
-		// transport/connection-level retry config
+		// transport/connection-level config
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff:           grpcConnectionBackoffConfig,
 			MinConnectTimeout: 10 * time.Second,


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/aks-secure-tls-bootstrap:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/aks-secure-tls-bootstrap.
   Note that to gain write access, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/aks-secure-tls-bootstrap/blob/main/README.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/aks-secure-tls-bootstrap/blob/main/.github/workflows/pr-lint.yaml.
-->

**What this PR does / why we need it**:

add grpc.ConnectParams with Backoff override to avoid conflicting retry/backoff strategies

 The gRPC subchannel reconnection backoff uses a default `MaxDelay` of **120 seconds**.
 After ~8 consecutive connection failures (common during cluster startup when the network
 path isn't yet established), the backoff reaches 120s between TCP connection attempts.
 Meanwhile, the RPC-level retry interceptor fires every ~2s but only polls the cached
 `TRANSIENT_FAILURE` state — it does NOT trigger new connections. This means the client
 can miss a 2+ minute window where the path becomes available.

 This is the root cause of `connection reset by peer` / `context deadline exceeded` failures
 observed across production and E2E clusters.

 **`MaxDelay: 3s`** — Caps subchannel reconnection backoff so the client retries a fresh
 TCP+TLS connection every ~3s instead of escalating to 120s. This keeps retry frequency
 aligned with the RPC-level retry interval (~2s) and ensures the client catches the narrow
 window when the network path becomes available.

 **`MinConnectTimeout: 5s`** — Reduces per-attempt connection timeout from the 20s default.
 When the LB path isn't ready, SYNs are black-holed (no RST, no response), so each attempt
 wastes the full timeout before retrying. 5s yields ~8s retry cycles while providing ample
 headroom for the actual handshake (<1s for healthy intra-Azure TCP + TLS 1.3).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #